### PR TITLE
Dark Changes

### DIFF
--- a/TCCTF_Core_v3/Entities/Materials/Construction/Material_Fuel.as
+++ b/TCCTF_Core_v3/Entities/Materials/Construction/Material_Fuel.as
@@ -4,7 +4,7 @@
 void onInit(CBlob@ this)
 {
 	this.Tag("explosive");
-	this.maxQuantity = 100;
+	this.maxQuantity = 50;
 	this.set_u8("fuel_energy", 100);
 	this.Tag("mat_gas");
 }

--- a/TCCTF_Core_v3/Entities/Structures/SmartStorageCore.as
+++ b/TCCTF_Core_v3/Entities/Structures/SmartStorageCore.as
@@ -211,6 +211,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 
 void smartStorageAdd(CBlob@ this, CBlob@ blob)
 {
+	blob.Tag("dead");
 	if (isServer())
 	{
 		string blobName = blob.getName();
@@ -243,7 +244,6 @@ void smartStorageAdd(CBlob@ this, CBlob@ blob)
 				params.write_u16(blob.getNetworkID());
 				this.SendCommand(this.getCommandID("update_storagelayers"), params);
 			}
-			blob.Tag("dead");
 			blob.server_Die();
 		}
 		else if (cur_quantity > 0)
@@ -256,11 +256,7 @@ void smartStorageAdd(CBlob@ this, CBlob@ blob)
 				this.Sync("Storage_"+blobName, true);
 				
 				if (amount < blobQuantity) blob.server_SetQuantity(blobQuantity - amount);
-				else
-				{
-					blob.Tag("dead");
-					blob.server_Die();
-				}
+				else blob.server_Die();
 			}
 		}
 	}

--- a/TCCTF_Core_v3/Entities/Vehicles/TurretAmmo.as
+++ b/TCCTF_Core_v3/Entities/Vehicles/TurretAmmo.as
@@ -16,7 +16,7 @@ void Turret_AddButtons(CBlob@ this, CBlob@ caller)
 {
 	const u16 ammoCount = this.get_u16("ammoCount");
 	const string ammoInventoryName = (this.exists("ammoInventoryName")) ? this.get_string("ammoInventoryName") : "Gatling Gun Ammo";
-	if (ammoCount > 0)
+	if (this.isOverlapping(caller) && ammoCount > 0)
 	{
 		CBitStream params;
 		params.write_u16(caller.getNetworkID());

--- a/TCCTF_Core_v3/Gamemode/Rules/Scripts/CTF/CTF.as
+++ b/TCCTF_Core_v3/Gamemode/Rules/Scripts/CTF/CTF.as
@@ -144,6 +144,7 @@ shared class CTFSpawns : RespawnSystem
 			}
 			if (player.getBlob() !is null)
 			{
+				print("Player "+p_info.username+" had blob during respawn");
 				CBlob@ blob = player.getBlob();
 				blob.server_SetPlayer(null);
 				blob.server_Die();
@@ -155,22 +156,28 @@ shared class CTFSpawns : RespawnSystem
 			{
 				string playerName = p_info.username;
 
-				for (u32 i = 0; i < sleepers.length; i++)
+				for (u8 i = 0; i < sleepers.length; i++)
 				{
 					CBlob@ sleeper = sleepers[i];
 					if (sleeper !is null && !sleeper.hasTag("dead") && sleeper.get_string("sleeper_name") == playerName)
 					{
 						CBlob@ oldBlob = player.getBlob(); // It's glitchy and spawns empty blobs on rejoin
-						if (oldBlob !is null) oldBlob.server_Die();
+						if (oldBlob !is null)
+						{
+							if (oldBlob.hasTag("sleeper")) print("Report this to DarkSlayer: oldblob sleeper: "+playerName);
+							else print("oldblob ded "+playerName);
+							oldBlob.server_Die();
+						}
+						p_info.spawnsCount++;
+						RemovePlayerFromSpawn(player);
 						if (!sleeper.hasTag("rejoined"))
 						{
-							p_info.spawnsCount++;
-							RemovePlayerFromSpawn(player);
 							sleeper.Tag("rejoined");
 							return;
 						}
 						sleeper.Untag("rejoined");
 						player.server_setCoins(sleeper.get_u16("sleeper_coins"));
+						sleeper.set_u16("sleeper_coins", 69);
 
 						sleeper.server_SetPlayer(player);
 						sleeper.set_bool("sleeper_sleeping", false);
@@ -181,8 +188,6 @@ shared class CTFSpawns : RespawnSystem
 						sleeper.SendCommand(sleeper.getCommandID("sleeper_set"), bt);
 
 						print(""+playerName + " joined, respawning him at sleeper " + sleeper.getName());
-						p_info.spawnsCount++;
-						RemovePlayerFromSpawn(player);
 						return;
 					}
 				}

--- a/TCCTF_Items_v3/Entities/Items/Crate/Crate.as
+++ b/TCCTF_Items_v3/Entities/Items/Crate/Crate.as
@@ -192,7 +192,7 @@ void Land(CBlob@ this)
 	if (parachute !is null && parachute.isVisible())
 	{
 		parachute.SetVisible(false);
-		ParticlesFromSprite(parachute);
+		if (!v_fastrender) ParticlesFromSprite(parachute);
 	}
 	// unpack immediately
 	if (this.exists("packed") && this.hasTag("unpack on land"))
@@ -375,8 +375,9 @@ void onRemoveFromInventory(CBlob@ this, CBlob@ blob)
 
 void onDie(CBlob@ this)
 {
-	if (isServer())
+	if (isClient())
 	{
+		if (v_fastrender) return;
 		this.getSprite().Gib();
 		Vec2f pos = this.getPosition();
 		Vec2f vel = this.getVelocity();

--- a/TCCTF_Items_v3/Entities/Items/Crate/Crate.cfg
+++ b/TCCTF_Items_v3/Entities/Items/Crate/Crate.cfg
@@ -1,9 +1,7 @@
 # Crate.cfg
 
 $sprite_factory                                   = generic_sprite
-@$sprite_scripts                                  = Wooden.as;
-													Crate.as;
-													FireAnim.as;
+@$sprite_scripts                                  = FireAnim.as;
 $sprite_texture                                   = Crate.png
 s32_sprite_frame_width                            = 32
 s32_sprite_frame_height                           = 16
@@ -88,7 +86,6 @@ $inventory_name                                   = Crate
 
 $name                                             = crate
 @$scripts                                         = DecayInWater.as;
-													Wooden.as;
 													Crate.as; 
 													ClamberableCollision.as;
 													VehicleAttachment.as;

--- a/TCCTF_Items_v3/Entities/Items/Mine/Mine.cfg
+++ b/TCCTF_Items_v3/Entities/Items/Mine/Mine.cfg
@@ -49,14 +49,13 @@ $inventory_factory                                =
 
 $name                                             = mine
 @$scripts                                         = Mine.as;
-													Wooden.as;
 													WoodOnHit.as;
 													Knockback.as;
 													GenericHit.as;
 													CheapFakeRolling.as;
 													ExplodeOnDie.as;
 													SetTeamToCarrier.as;
-f32 health                                        = 2.5
+f32 health                                        = 1.5
 $inventory_name                                   = Mine
 $inventory_icon                                   = -
 u8 inventory_icon_frame                           = 0

--- a/TCCTF_Misc_v3/Entities/Misc/Gases/AcidGas/AcidGas.as
+++ b/TCCTF_Misc_v3/Entities/Misc/Gases/AcidGas/AcidGas.as
@@ -94,17 +94,11 @@ void onTick(CBlob@ this)
 				}
 			}
 		}
-				
-		if (hit)
+		
+		if (this.isOnScreen() && hit && client)
 		{
-			if (client)
-			{
-				this.getSprite().PlaySound("Steam", 1, 1);
-				if (this.isOnScreen())
-				{
-					MakeSmokeParticle(this, hit_position, Vec2f(0, -1), "LargeSmoke");
-				}
-			}
+			this.getSprite().PlaySound("Steam", 1, 1);
+			if (!v_fastrender) MakeSmokeParticle(this, hit_position, Vec2f(0, -1), "LargeSmoke");
 		}
 		
 		if (client && this.isOnScreen())

--- a/TCCTF_Structures_v3/Entities/Structures/Altar/SwagLag/AltarSwagLag.as
+++ b/TCCTF_Structures_v3/Entities/Structures/Altar/SwagLag/AltarSwagLag.as
@@ -58,8 +58,8 @@ void onInit(CBlob@ this)
 	
 	AddIconToken("$icon_swaglag_offering_2$", "AltarSwagLag_Icons.png", Vec2f(24, 24), 2);
 	{
-		ShopItem@ s = addShopItem(this, "Offering of Doritos", "$icon_swaglag_offering_2$", "offering_doritos", "Sacrifice some money to buy Doritos from the built-in vending machine.");
-		AddRequirement(s.requirements, "coin", "", "Coins", 50);
+		ShopItem@ s = addShopItem(this, "Offering of Doritos", "$icon_swaglag_offering_2$", "offering_doritos", "Sacrifice some money to buy a pack of a dozen Doritos.");
+		AddRequirement(s.requirements, "coin", "", "Coins", 750);
 		s.customButton = true;
 		s.buttonwidth = 1;	
 		s.buttonheight = 1;
@@ -189,12 +189,13 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 						}
 						else if (data == "offering_doritos")
 						{
-							this.add_f32("deity_power", 10);
+							this.add_f32("deity_power", 100);
 							if (isServer()) this.Sync("deity_power", false);
 							
 							if (isServer())
 							{
 								CBlob@ item = server_CreateBlob("doritos", this.getTeamNum(), this.getPosition());
+								item.server_SetQuantity(12);
 								callerBlob.server_Pickup(item);
 							}
 							

--- a/TCCTF_Structures_v3/Entities/Structures/Zapper/Zapper.as
+++ b/TCCTF_Structures_v3/Entities/Structures/Zapper/Zapper.as
@@ -67,14 +67,6 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		if (this.getDistanceTo(caller) <= 48)
 		{
-			{
-				bool state = this.get_bool("security_state");
-				CBitStream params;
-				params.write_bool(!state);
-				caller.CreateGenericButton((state ? 27 : 23), Vec2f(0, -7), this, 
-					this.getCommandID("security_set_state"), getTranslatedString(state ? "OFF" : "ON"), params);
-			}
-
 			Turret_AddButtons(this, caller);
 		}
 	}

--- a/TCCTF_Weapons_v3/Entities/Guns/Flamethrower/Flame/Flame.as
+++ b/TCCTF_Weapons_v3/Entities/Guns/Flamethrower/Flame/Flame.as
@@ -56,7 +56,7 @@ void onTick(CBlob@ this)
 	if (isClient())
 	{
 		this.getSprite().SetFrame(XORRandom(6));
-		ParticleAnimated("SmallFire", this.getPosition() + Vec2f(XORRandom(16) - 8, XORRandom(16) - 8), Vec2f(0, 0), 0, 1.0f, 2, 0.25f, false);
+		if (!v_fastrender) ParticleAnimated("SmallFire", this.getPosition() + Vec2f(XORRandom(16) - 8, XORRandom(16) - 8), Vec2f(0, 0), 0, 1.0f, 2, 0.25f, false);
 	}
 }
 

--- a/TCCTF_Weapons_v3/Entities/Guns/InfernoCannon/InfernoFlame/InfernoProjectile.as
+++ b/TCCTF_Weapons_v3/Entities/Guns/InfernoCannon/InfernoFlame/InfernoProjectile.as
@@ -11,6 +11,7 @@ string[] particles =
 void onInit(CBlob@ this)
 {
 	this.getShape().SetGravityScale(0.5f);
+	this.server_SetTimeToDie(10);
 
 	this.set_string("custom_explosion_sound", "InfernoCannon_Explosion");
 
@@ -95,7 +96,7 @@ void DoExplosion(CBlob@ this)
 			blob.server_SetTimeToDie(5 + XORRandom(5));
 		}
 
-		for(int i = 0; i < 20; i++)
+		for(int i = 0; i < 15; i++)
 		{
 			map.server_setFireWorldspace(pos + Vec2f(8 - XORRandom(16), 8 - XORRandom(16)) * 8, true);
 		}
@@ -109,6 +110,7 @@ void DoExplosion(CBlob@ this)
 
 void MakeParticle(CBlob@ this, const Vec2f pos, const Vec2f vel, const string filename = "SmallSteam")
 {
+	if (v_fastrender) return;
 	if (!isClient()) return;
 
 	ParticleAnimated(filename, this.getPosition() + pos, vel, float(XORRandom(360)), 1.0f + (XORRandom(100) * 0.01f), 1 + XORRandom(8), XORRandom(100) * -0.0001f, true);

--- a/TCCTF_Weapons_v3/Entities/Guns/Napalmer/Napalm/Napalm.as
+++ b/TCCTF_Weapons_v3/Entities/Guns/Napalmer/Napalm/Napalm.as
@@ -4,7 +4,7 @@ void onInit(CBlob@ this)
 {
 	this.server_SetTimeToDie(5 + XORRandom(30));
 	
-	this.getCurrentScript().tickFrequency = 10;
+	this.getCurrentScript().tickFrequency = 20;
 	
 	this.SetLight(true);
 	this.SetLightRadius(64.0f);
@@ -57,6 +57,7 @@ void onTick(CBlob@ this)
 
 void onTick(CSprite@ this)
 {
+	if (v_fastrender) return;
 	if (isClient())
 	{
 		CBlob@ blob = this.getBlob();

--- a/TCCTF_Weapons_v3/Entities/Guns/Napalmer/Napalmer.as
+++ b/TCCTF_Weapons_v3/Entities/Guns/Napalmer/Napalmer.as
@@ -7,9 +7,9 @@ void onInit(CBlob@ this)
 
 	//General
 	//settings.CLIP = 0; //Amount of ammunition in the gun at creation
-	settings.TOTAL = 50; //Max amount of ammo that can be in a clip
-	settings.FIRE_INTERVAL = 2; //Time in between shots
-	settings.RELOAD_TIME = 60; //Time it takes to reload (in ticks)
+	settings.TOTAL = 25; //Max amount of ammo that can be in a clip
+	settings.FIRE_INTERVAL = 3; //Time in between shots
+	settings.RELOAD_TIME = 90; //Time it takes to reload (in ticks)
 	settings.AMMO_BLOB = "mat_fuel"; //Ammunition the gun takes
 
 	//Bullet

--- a/TCCTF_Weapons_v3/Entities/Weapons/Fragmine/FragMine.cfg
+++ b/TCCTF_Weapons_v3/Entities/Weapons/Fragmine/FragMine.cfg
@@ -9,23 +9,6 @@ f32 sprite_offset_x                               = 0
 f32 sprite_offset_y                               = 0
 
 $sprite_gibs_start                                = *start*
-
-	$gib_type                                     = predefined
-	$gib_style                                    = dirt
-	u8_gib_count                                  = 5
-	@u8_gib_frame                                 = 4; 5; 6; 7;
-	f32 velocity                                  = 15.0
-	f32 offset_x                                  = 0.0
-	f32 offset_y                                  = 0.0
-
-	$gib_type                                     = predefined
-	$gib_style                                    = stone
-	u8_gib_count                                  = 2
-	@u8_gib_frame                                 = 1; 2; 3; 4; 5; 6; 7;
-	f32 velocity                                  = 10.0
-	f32 offset_x                                  = 0.0
-	f32 offset_y                                  = 0.0
-
 $sprite_gibs_end                                  = *end*
 
 $sprite_animation_start                           = *start*
@@ -66,14 +49,13 @@ $inventory_factory                                =
 
 $name                                             = fragmine
 @$scripts                                         = FragMine.as;
-													Wooden.as;
 													WoodenHit.as;
 													Knockback.as;
 													GenericHit.as;
 													CheapFakeRolling.as;
 													ExplodeOnDie.as;
 													SetTeamToCarrier.as;
-f32 health                                        = 2.5
+f32 health                                        = 3.5
 $inventory_name                                   = Fragmentation Mine
 $inventory_icon                                   = -
 u8 inventory_icon_frame                           = 0


### PR DESCRIPTION
Turret Buttons
- Zapper on/off button removed, can only turn on/off at sec station since people keep accidentally turning it off
- Take ammo button range is reduced to avoid accidentally taking ammo out
Lag Reduction
- Mostly for players who turned on Fast Render they wont lag as much
- Swaglag altar less laggy from dorito spam
- Less laggy crates, mines, napalm, acid, blaze, etc.
Other
- Slight quality of life change to smart storage ( wont hear fake explosions )
- Attempt to fix sleepers