### PR TITLE
Altar Tweaks

### DIFF
--- a/TCCTF_Characters_v3/Entities/Characters/Builder/BlockPlacement.as
+++ b/TCCTF_Characters_v3/Entities/Characters/Builder/BlockPlacement.as
@@ -55,7 +55,7 @@ void PlaceBlock(CBlob@ this, u8 index, Vec2f cursorPos)
 				&& bc.tile != CMap::tile_copperingot && bc.tile != CMap::tile_steelingot && bc.tile != CMap::tile_ironingot)
 				{
 					//print("free block chance: " + Maths::Min((altar.get_f32("deity_power") * 0.01f),MAX_FREE_BLOCK_CHANCE));
-					if (XORRandom(100) < Maths::Min((altar.get_f32("deity_power") * 0.01f),MAX_FREE_BLOCK_CHANCE))
+					if (XORRandom(100) < Maths::Min(Maths::Sqrt(altar.get_f32("deity_power")),100))
 					{
 						take = false;
 						// print("free block!");

--- a/TCCTF_Characters_v3/Entities/Characters/Builder/CommonBuilderBlocks.as
+++ b/TCCTF_Characters_v3/Entities/Characters/Builder/CommonBuilderBlocks.as
@@ -319,11 +319,6 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks, int teamnum = 7)
 		AddRequirement(b.reqs, "blob", "mat_mithrilingot", "Mithril Ingots", 30);
 		blocks[0].push_back(b);
 	}
-	{
-		BuildBlock b(CMap::tile_kudzu, "kudzu", "$kudzu_block$", "Mostly decorative kudzu leaves \n ");
-		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 20);
-		blocks[0].push_back(b);
-	}
 	
 	
 	// {

--- a/TCCTF_Structures_v3/Entities/Structures/Altar/Altar.as
+++ b/TCCTF_Structures_v3/Entities/Structures/Altar/Altar.as
@@ -132,7 +132,12 @@ void onInit(CBlob@ this)
 		{
 			ShopItem@ s = addShopItem(this, "Foghorn, God of Poultry", "$icon_foghorn$", "altar_foghorn", "The god of poultry. Allows one to summon ally chickens, and morph into a chicken.");
 			AddRequirement(s.requirements, "no more global", "altar_foghorn", "Altar of Foghorn", 1);
-			AddRequirement(s.requirements, "blob", "chicken", "Chicken", 20+XORRandom(60));
+			if (XORRandom(2) == 0) AddRequirement(s.requirements, "blob", "soldierchicken", "soldierchicken", 1);
+			else
+			{
+				AddRequirement(s.requirements, "blob", "chicken", "Chicken", 15+XORRandom(40));
+				AddRequirement(s.requirements, "blob", "phone", "UPF Phone", 1);
+			}
 			AddRequirement(s.requirements, "coin", "", "Coins", 1000+XORRandom(3000));
 			s.customButton = true;
 			s.buttonwidth = 2;	

--- a/TCCTF_Structures_v3/Entities/Structures/Altar/Dragonfriend/AltarDragonfriend.as
+++ b/TCCTF_Structures_v3/Entities/Structures/Altar/Dragonfriend/AltarDragonfriend.as
@@ -49,7 +49,7 @@ void onInit(CBlob@ this)
 	{
 		ShopItem@ s = addShopItem(this, "Offering of the Meteor", "$icon_dragonfriend_offering_1$", "offering_meteor", "Offer 10000 coins to summon a meteor.");
 		//AddRequirement(s.requirements, "blob", "mat_goldingot", "Gold Ingot", 100);
-		AddRequirement(s.requirements, "coin", "", "Coins", 10000);
+		AddRequirement(s.requirements, "coin", "", "Coins", 8000 + XORRandom(4000));
 		s.customButton = true;
 		s.buttonwidth = 1;	
 		s.buttonheight = 1;
@@ -250,10 +250,8 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 							{	
 								f32 stonks_value = this.get_f32("stonks_value");
 							
-								this.add_f32("deity_power", stonks_value * 0.95f);
+								this.add_f32("deity_power", stonks_value * 1.25f);
 								if (isServer()) this.Sync("deity_power", true);
-							
-								server_DropCoins(this.getPosition(), stonks_value * 0.05f);
 							}
 							
 							if (isClient())
@@ -265,15 +263,13 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 						{
 							if (isServer())
 							{
-								this.add_f32("deity_power", 9999);
+								this.add_f32("deity_power", 7000);
 								if (isServer()) this.Sync("deity_power", true);
 							
 								f32 map_width = getMap().tilemapwidth * 8.00f;
 								CBlob@ item = server_CreateBlob("meteor", this.getTeamNum(), Vec2f(XORRandom(map_width), 0));
 								item.Tag("dragonfriend");
 								item.set_f32("deity_power", this.get_f32("deity_power")/10000);
-								
-								server_DropCoins(this.getPosition(), XORRandom(100));
 							}
 							
 							if (isClient())

--- a/TCCTF_Structures_v3/Entities/Structures/Altar/Foghorn/AltarFoghorn.as
+++ b/TCCTF_Structures_v3/Entities/Structures/Altar/Foghorn/AltarFoghorn.as
@@ -30,6 +30,29 @@ void onInit(CBlob@ this)
 		
 		s.spawnNothing = true;
 	}
+	{
+		ShopItem@ s = addShopItem(this, "Offer Scrub's Chow", "$foodcan$", "offering_scrubs", "Sacrifice Scrub's chow in return for power.");
+		AddRequirement(s.requirements, "blob", "foodcan", "Scrub's Chow", 20);
+		s.customButton = true;
+		s.buttonwidth = 1;	
+		s.buttonheight = 1;
+		
+		s.spawnNothing = true;
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Chicken's Outfit", "$chickentools$", "chickentools", "Morph into a chicken using chickentools.", true);
+		AddRequirement(s.requirements, "blob", "chicken", "Chicken", 1);
+		AddRequirement(s.requirements, "coin", "", "Coins", 1500);
+
+		s.spawnNothing = true;
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Recruit a UPF Soldier", "$soldierchicken$", "offering_summon", "Enlist a UPF chicken soldier.", true);
+		AddRequirement(s.requirements, "blob", "egg", "Egg", 1);
+		AddRequirement(s.requirements, "coin", "", "Coins", 1750);
+
+		s.spawnNothing = true;
+	}
 	
 	this.set_f32("deity_power", 0);
 }
@@ -105,55 +128,21 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 					}
 					else if (data == "offering_phone")
 					{
-						if (!this.hasTag("Scrubs"))
-						{
-							ShopItem@ s = addShopItem(this, "Offer Scrub's Chow", "$foodcan$", "offering_scrubs", "Sacrifice Scrub's chow in return for power.");
-							AddRequirement(s.requirements, "blob", "foodcan", "Scrub's Chow", 40);
-							s.customButton = true;
-							s.buttonwidth = 1;	
-							s.buttonheight = 1;
-							
-							s.spawnNothing = true;
-							this.Tag("Scrubs");
-						}
-						if (!this.hasTag("ChickenTools"))
-						{
-							ShopItem@ s = addShopItem(this, "Chicken's Outfit", "$chickentools$", "chickentools", "Morph into a chicken using chickentools.", true);
-							AddRequirement(s.requirements, "blob", "chicken", "Chicken", 1);
-							AddRequirement(s.requirements, "coin", "", "Coins", 1500);
+						this.add_f32("deity_power", 2500);
+						if (isServer()) this.Sync("deity_power", false);
+						this.set_u8("maxChickens", Maths::FastSqrt(Maths::FastSqrt(this.get_f32("deity_power"))));
+						CBlob@[] chickens;
+						getBlobsByTag("combat chicken", chickens);
 
-							s.spawnNothing = true;
-							this.Tag("ChickenTools");
-						}
-						if (!this.hasTag("Summon"))
+						if (this.get_f32("deity_power") > 7500)
 						{
-							this.add_f32("deity_power", 250);
-							if (isServer()) this.Sync("deity_power", false);
-							ShopItem@ s = addShopItem(this, "Recruit a UPF Soldier", "$soldierchicken$", "offering_summon", "Enlist a UPF chicken soldier.", true);
-							AddRequirement(s.requirements, "blob", "chicken", "Chicken", 1);
-							AddRequirement(s.requirements, "coin", "", "Coins", 1750);
-
-							s.spawnNothing = true;
-							this.Tag("Summon");
+							this.set_string("classtype", "heavychicken");
+							this.set_u8("maxChickens", this.get_u8("maxChickens"));
 						}
-						else 
+						else if (this.get_f32("deity_power") > 1500)
 						{
-							this.add_f32("deity_power", 2500);
-							if (isServer()) this.Sync("deity_power", false);
-							this.set_u8("maxChickens", Maths::FastSqrt(Maths::FastSqrt(this.get_f32("deity_power"))));
-							CBlob@[] chickens;
-							getBlobsByTag("combat chicken", chickens);
-
-							if (this.get_f32("deity_power") > 7500)
-							{
-								this.set_string("classtype", "heavychicken");
-								this.set_u8("maxChickens", this.get_u8("maxChickens"));
-							}
-							else if (this.get_f32("deity_power") > 1500)
-							{
-								this.set_string("classtype", "soldierchicken");
-								this.set_u8("maxChickens", this.get_u8("maxChickens"));
-							}
+							this.set_string("classtype", "soldierchicken");
+							this.set_u8("maxChickens", this.get_u8("maxChickens"));
 						}
 					}
 					else if (isServer() && data == "chickentools")

--- a/TCCTF_Structures_v3/Entities/Structures/Altar/Foghorn/AltarFoghorn.as
+++ b/TCCTF_Structures_v3/Entities/Structures/Altar/Foghorn/AltarFoghorn.as
@@ -54,7 +54,7 @@ void onInit(CBlob@ this)
 		s.spawnNothing = true;
 	}
 	
-	this.set_f32("deity_power", 0);
+	this.set_f32("deity_power", 250);
 }
 
 void onTick(CBlob@ this)

--- a/TCCTF_Structures_v3/Entities/Structures/Altar/Mason/AltarMason.as
+++ b/TCCTF_Structures_v3/Entities/Structures/Altar/Mason/AltarMason.as
@@ -14,7 +14,7 @@ void onInit(CBlob@ this)
 
 	//this.set_f32("deity_power",10000); //for testing if the cap is actually working
 
-	this.getCurrentScript().tickFrequency = 15;
+	this.getCurrentScript().tickFrequency = 30;
 
 	CSprite@ sprite = this.getSprite();
 	sprite.SetEmitSound("Disc_MountainKing.ogg");
@@ -25,24 +25,11 @@ void onInit(CBlob@ this)
 	AddIconToken("$icon_mason_follower$", "InteractionIcons.png", Vec2f(32, 32), 11);
 	{
 		ShopItem@ s = addShopItem(this, "Rite of Grand Mason", "$icon_mason_follower$", "follower", "Gain Grand Mason's respect by offering him a huge pile of rocks.");
-		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", 1000);
+		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", 500+XORRandom(750));
 		s.customButton = true;
 		s.buttonwidth = 2;	
 		s.buttonheight = 2;
 		
-		s.spawnNothing = true;
-	}
-	{
-		ShopItem@ s = addShopItem(this, "Building for Dummies", "$artisancertificate$", "artisancertificate", "Simplified Builder manuscript for building cooperation.", true);
-		AddRequirement(s.requirements, "coin", "", "Coins", 200);
-		
-		s.spawnNothing = true;
-	}
-	{
-		ShopItem@ s = addShopItem(this, "Engineer's Tools", "$engineertools$", "engineertools", "Engineer's Tools for advanced builders.", true);
-		AddRequirement(s.requirements, "coin", "", "Coins", 250);
-		AddRequirement(s.requirements, "blob", "mat_ironingot", "Iron Ingot", 4);
-
 		s.spawnNothing = true;
 	}
 }


### PR DESCRIPTION
- Foghorn altar will accept either soldierchicken body or a phone + chickens
- Foghorn altar no longer needs to upgrade altar to unlock chicken summonings
- Fixed mason
- Dragon altar balancing
- More random price trolling